### PR TITLE
Removing head tags due to the way meteor automatically adds these to …

### DIFF
--- a/simple-todos-angular.html
+++ b/simple-todos-angular.html
@@ -1,7 +1,3 @@
-<head>
-  <title>Todo List</title>
-</head>
-
 <body ng-include="'todos-list.ng.html'"
       ng-controller="TodosListCtrl">
 </body>


### PR DESCRIPTION
Removing head tags due to the way meteor automatically adds these to the template. This was causing a 'tried to load angular more than once error' when following the tutorial found here: https://www.meteor.com/tutorials/angular/creating-an-app
